### PR TITLE
Add settings panel for weather forecasts

### DIFF
--- a/src/components/ui/settings-section.tsx
+++ b/src/components/ui/settings-section.tsx
@@ -1,0 +1,36 @@
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { UserSettings } from "@/types";
+
+interface SettingsSectionProps {
+  settings: UserSettings;
+  onChange: (s: UserSettings) => void;
+}
+
+export function SettingsSection({ settings, onChange }: SettingsSectionProps) {
+  return (
+    <Card className="p-4 space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-1">Start date &amp; time</label>
+        <Input
+          type="datetime-local"
+          value={settings.weatherStart.slice(0,16)}
+          onChange={(e) =>
+            onChange({ ...settings, weatherStart: e.target.value })
+          }
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Average speed (km/h)</label>
+        <Input
+          type="number"
+          value={settings.averageSpeed}
+          min={1}
+          onChange={(e) =>
+            onChange({ ...settings, averageSpeed: parseFloat(e.target.value) || 0 })
+          }
+        />
+      </div>
+    </Card>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -30,3 +30,8 @@ export interface WeatherCache {
     timestamp: number;
   };
 }
+
+export interface UserSettings {
+  weatherStart: string;
+  averageSpeed: number;
+}


### PR DESCRIPTION
## Summary
- allow selecting start date and average speed for forecasts
- compute arrival times using speed
- show arrival times on weather labels and bump font size
- persist settings in localStorage via utilities
- refresh cached GPX weather when the date setting changes

## Testing
- `npm run lint` *(fails: 19 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6884f110151c8331870b81172255648a