### PR TITLE
Improve refresh and map behavior

### DIFF
--- a/src/components/ui/track-list.tsx
+++ b/src/components/ui/track-list.tsx
@@ -33,7 +33,7 @@ interface TrackListProps {
   tracks: ProcessedTrack[];
   selectedTrackId?: string;
   onSelectTrack: (trackId: string) => void;
-  onDeleteTrack: (trackId: string) => void;
+  onDeleteTrack: (trackId: string | string[]) => void;
   settings: UserSettings;
 }
 
@@ -85,7 +85,7 @@ export function TrackList({
   const confirmDelete = () => {
     // Convert Set to Array and send all track IDs at once
     const trackIdsToDelete = Array.from(selectedTracks);
-    onDeleteTrack(trackIdsToDelete as unknown as string);
+    onDeleteTrack(trackIdsToDelete);
     setSelectedTracks(new Set());
     setShowDeleteConfirm(false);
   };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -287,8 +287,17 @@ export function getWeatherCache(): Record<string, { data: DailyWeatherData; time
   }
 }
 
+// Clear the entire weather cache
+export function clearWeatherCache(): void {
+  try {
+    localStorage.removeItem('weather-cache');
+  } catch (error) {
+    console.error('Error clearing weather cache:', error);
+  }
+}
+
 // Save tracks to localStorage
-export function saveTracks(tracks: any[]): void {
+export function saveTracks(tracks: ProcessedTrack[]): void {
   try {
     localStorage.setItem('saved-tracks', JSON.stringify(tracks));
   } catch (error) {
@@ -297,10 +306,10 @@ export function saveTracks(tracks: any[]): void {
 }
 
 // Load tracks from localStorage
-export function loadTracks(): any[] {
+export function loadTracks(): ProcessedTrack[] {
   try {
     const saved = localStorage.getItem('saved-tracks');
-    return saved ? JSON.parse(saved) : [];
+    return saved ? JSON.parse(saved) as ProcessedTrack[] : [];
   } catch (error) {
     console.error('Error loading tracks:', error);
     return [];


### PR DESCRIPTION
## Summary
- clear weather cache on refresh and always re-fetch
- don't reset map view on clear
- auto-zoom to all tracks on first load
- show timestamp for weather data
- auto-select the first loaded track
- allow deleting multiple tracks
- add strong typing for saved tracks

## Testing
- `npm run lint` *(fails: `@typescript-eslint` errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885e69dfcac833198404fdb0f84a489