### PR TITLE
Add daily weather table and fix build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
+        "html-to-image": "^1.11.11",
         "input-otp": "^1.2.4",
         "jspdf": "^3.0.1",
         "lucide-react": "^0.446.0",
@@ -4903,6 +4904,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/html2canvas": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^1.0.0",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "html-to-image": "^1.11.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/src/components/ui/settings-section.tsx
+++ b/src/components/ui/settings-section.tsx
@@ -1,6 +1,4 @@
 import { Card } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { CalendarTimePicker } from "@/components/ui/calendar-time-picker";
 import { UserSettings } from "@/types";
 
 interface SettingsSectionProps {
@@ -8,38 +6,8 @@ interface SettingsSectionProps {
   onChange: (s: UserSettings) => void;
 }
 
-export function SettingsSection({ settings, onChange }: SettingsSectionProps) {
+export function SettingsSection({}: SettingsSectionProps) {
   return (
-    <Card className="p-4 space-y-4">
-      <div>
-        <label className="block text-sm font-medium mb-1">Start date &amp; time</label>
-        <CalendarTimePicker
-          value={settings.weatherStart}
-          onChange={(v) => onChange({ ...settings, weatherStart: v })}
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium mb-1">Average speed (km/h)</label>
-        <Input
-          type="number"
-          value={settings.averageSpeed}
-          min={1}
-          onChange={(e) =>
-            onChange({ ...settings, averageSpeed: parseFloat(e.target.value) || 0 })
-          }
-        />
-      </div>
-      <div>
-        <label className="block text-sm font-medium mb-1">Hourly margin (h)</label>
-        <Input
-          type="number"
-          min={2}
-          value={settings.hourlyMargin}
-          onChange={(e) =>
-            onChange({ ...settings, hourlyMargin: Math.max(2, parseInt(e.target.value) || 0) })
-          }
-        />
-      </div>
-    </Card>
+    <Card className="p-4 text-sm text-muted-foreground">No settings available</Card>
   );
 }

--- a/src/components/ui/track-list.tsx
+++ b/src/components/ui/track-list.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { ProcessedTrack, UserSettings } from "@/types";
+import { ProcessedTrack } from "@/types";
 import { formatDistanceToNow } from "date-fns";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -34,15 +34,13 @@ interface TrackListProps {
   selectedTrackId?: string;
   onSelectTrack: (trackId: string) => void;
   onDeleteTrack: (trackId: string | string[]) => void;
-  settings: UserSettings;
 }
 
-export function TrackList({ 
-  tracks, 
-  selectedTrackId, 
+export function TrackList({
+  tracks,
+  selectedTrackId,
   onSelectTrack, 
-  onDeleteTrack,
-  settings
+  onDeleteTrack
 }: TrackListProps) {
   const [selectedTracks, setSelectedTracks] = useState<Set<string>>(new Set());
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -100,7 +98,7 @@ export function TrackList({
     const firstId = Array.from(selectedTracks)[0];
     const track = tracks.find(t => t.id === firstId);
     if (track) {
-      exportWeatherPdf(track, settings, exportTitle);
+      exportWeatherPdf(track, exportTitle);
     }
     setShowExportDialog(false);
   };

--- a/src/components/ui/weather-table.tsx
+++ b/src/components/ui/weather-table.tsx
@@ -1,0 +1,64 @@
+import { useRef } from 'react';
+import { ProcessedTrack } from '@/types';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './table';
+import { Button } from './button';
+import { toPng } from 'html-to-image';
+
+interface WeatherTableProps {
+  track: ProcessedTrack | null;
+}
+
+export function WeatherTable({ track }: WeatherTableProps) {
+  const tableRef = useRef<HTMLDivElement>(null);
+
+  const exportPng = async () => {
+    if (!tableRef.current) return;
+    const dataUrl = await toPng(tableRef.current);
+    const link = document.createElement('a');
+    link.href = dataUrl;
+    link.download = 'weather.png';
+    link.click();
+  };
+
+  if (!track || !track.weatherData || !track.sampledPoints) {
+    return (
+      <div className="p-4 text-sm text-muted-foreground">No weather data available.</div>
+    );
+  }
+
+  const arrow = (deg: number) => {
+    const arrows = ['↑','↗','→','↘','↓','↙','←','↖'];
+    const idx = Math.round(deg / 45) % 8;
+    return arrows[idx];
+  };
+
+  return (
+    <div className="p-4 space-y-2">
+      <div className="flex justify-end">
+        <Button size="sm" onClick={exportPng}>Export PNG</Button>
+      </div>
+      <div ref={tableRef} className="overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>#</TableHead>
+              <TableHead>Temp&nbsp;°C</TableHead>
+              <TableHead>Wind</TableHead>
+              <TableHead>Rain&nbsp;mm</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {track.weatherData.map((w, idx) => (
+              <TableRow key={idx}>
+                <TableCell>{idx + 1}</TableCell>
+                <TableCell>{`${w.apparent_temperature_min.toFixed(0)}-${w.apparent_temperature_max.toFixed(0)}`}</TableCell>
+                <TableCell>{`${w.wind_speed_10m_max.toFixed(0)} km/h ${arrow(w.wind_direction_10m_dominant)}`}</TableCell>
+                <TableCell>{w.rain_sum.toFixed(1)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,12 +1,16 @@
 export interface WeatherData {
-  /** Temperature at the selected time */
-  temperature: number;
-  /** Maximum temperature within the hourly margin */
-  temperature_2m_max: number;
-  /** Minimum temperature within the hourly margin */
-  temperature_2m_min: number;
-  precipitation_probability_max: number;
+  /** ISO date for the forecast */
   time: string;
+  /** Maximum apparent temperature for the day */
+  apparent_temperature_max: number;
+  /** Minimum apparent temperature for the day */
+  apparent_temperature_min: number;
+  /** Maximum wind speed */
+  wind_speed_10m_max: number;
+  /** Dominant wind direction in degrees */
+  wind_direction_10m_dominant: number;
+  /** Total rain for the day */
+  rain_sum: number;
 }
 
 export interface GpxPoint {
@@ -29,12 +33,13 @@ export interface ProcessedTrack {
 }
 
 export interface DailyWeatherData {
-  /** Array of ISO timestamps */
+  /** Array with a single ISO date */
   time: string[];
-  /** Temperature forecast for each hour */
-  temperature_2m: number[];
-  /** Precipitation probability for each hour */
-  precipitation_probability: number[];
+  apparent_temperature_max: number[];
+  apparent_temperature_min: number[];
+  wind_speed_10m_max: number[];
+  wind_direction_10m_dominant: number[];
+  rain_sum: number[];
 }
 
 export interface WeatherCache {
@@ -45,8 +50,5 @@ export interface WeatherCache {
 }
 
 export interface UserSettings {
-  weatherStart: string;
-  averageSpeed: number;
-  /** Number of hours before/after the selected time to include in the weather range */
-  hourlyMargin: number;
+  // Intentionally left blank for future preferences
 }


### PR DESCRIPTION
## Summary
- switch weather API to use daily forecast
- drop hourly settings UI and update data types
- show weather details in a new table with PNG export
- fix unused type import and update lockfile

## Testing
- `npm install`
- `npm run lint` *(fails: multiple lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885f5d7b850833182379e47e563dd41