### PR TITLE
Add forecast date and improve weather table

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,8 @@ import {
   saveTracks,
   loadSettings,
   saveSettings,
-  clearWeatherCache
+  clearWeatherCache,
+  windArrow
 } from '@/lib/utils';
 
 function App() {
@@ -148,7 +149,7 @@ function App() {
           
           // Fetch weather data for each sampled point
           const weatherData = await Promise.all(
-            sampledPoints.map(point => fetchWeather(point.lat, point.lon))
+            sampledPoints.map(point => fetchWeather(point.lat, point.lon, settings.forecastDate))
           );
 
           return {
@@ -212,7 +213,7 @@ function App() {
             : sampledPoints;
 
           const weatherData = await Promise.all(
-            weatherPoints.map(point => fetchWeather(point.lat, point.lon))
+            weatherPoints.map(point => fetchWeather(point.lat, point.lon, settings.forecastDate))
           );
 
           return {
@@ -497,7 +498,7 @@ function App() {
                     const labelTemp = weather
                       ? `${weather.apparent_temperature_min.toFixed(1)}-${weather.apparent_temperature_max.toFixed(1)}°C`
                       : 'N/A';
-                    const labelWind = weather ? `${weather.wind_speed_10m_max.toFixed(0)} km/h` : '';
+                    const labelWind = weather ? `${weather.wind_speed_10m_max.toFixed(0)} km/h ${windArrow(weather.wind_direction_10m_dominant)}` : '';
                     const labelRain = weather ? `${weather.rain_sum.toFixed(1)} mm` : '';
 
                     return {
@@ -649,7 +650,7 @@ function App() {
           
           // Fetch weather data for each sampled point
           const weatherData = await Promise.all(
-            sampledPoints.map(point => fetchWeather(point.lat, point.lon))
+            sampledPoints.map(point => fetchWeather(point.lat, point.lon, settings.forecastDate))
           );
 
           // Extract file name without extension and path

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -1,0 +1,44 @@
+'use client'
+import * as React from 'react'
+import { ChevronDownIcon } from 'lucide-react'
+import { Button } from './button'
+import { Calendar } from './calendar'
+import { Popover, PopoverContent, PopoverTrigger } from './popover'
+
+interface DatePickerProps {
+  value: string
+  onChange: (value: string) => void
+  minDate?: Date
+  maxDate?: Date
+}
+
+export function DatePicker({ value, onChange, minDate, maxDate }: DatePickerProps) {
+  const [open, setOpen] = React.useState(false)
+  const date = new Date(value)
+
+  const handleSelect = (d?: Date) => {
+    if (!d) return
+    onChange(d.toISOString().split('T')[0])
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className="w-32 justify-between font-normal">
+          {date.toLocaleDateString()}
+          <ChevronDownIcon />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={date}
+          onSelect={handleSelect}
+          fromDate={minDate}
+          toDate={maxDate}
+        />
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/components/ui/settings-section.tsx
+++ b/src/components/ui/settings-section.tsx
@@ -1,4 +1,6 @@
 import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { DatePicker } from "@/components/ui/date-picker";
 import { UserSettings } from "@/types";
 
 interface SettingsSectionProps {
@@ -6,8 +8,23 @@ interface SettingsSectionProps {
   onChange: (s: UserSettings) => void;
 }
 
-export function SettingsSection({}: SettingsSectionProps) {
+export function SettingsSection({ settings, onChange }: SettingsSectionProps) {
+  const from = new Date();
+  from.setDate(from.getDate() - 1);
+  const to = new Date();
+  to.setDate(to.getDate() + 7);
+
   return (
-    <Card className="p-4 text-sm text-muted-foreground">No settings available</Card>
+    <Card className="p-4 space-y-4">
+      <div className="flex flex-col gap-2">
+        <Label className="px-1">Forecast Date</Label>
+        <DatePicker
+          value={settings.forecastDate}
+          onChange={(d) => onChange({ ...settings, forecastDate: d })}
+          minDate={from}
+          maxDate={to}
+        />
+      </div>
+    </Card>
   );
 }

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -20,7 +20,11 @@ const TableHeader = React.forwardRef<
   HTMLTableSectionElement,
   React.HTMLAttributes<HTMLTableSectionElement>
 >(({ className, ...props }, ref) => (
-  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+  <thead
+    ref={ref}
+    className={cn('[&_tr]:border-b sticky top-0 bg-background', className)}
+    {...props}
+  />
 ));
 TableHeader.displayName = 'TableHeader';
 

--- a/src/components/ui/weather-table.tsx
+++ b/src/components/ui/weather-table.tsx
@@ -3,6 +3,7 @@ import { ProcessedTrack } from '@/types';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './table';
 import { Button } from './button';
 import { toPng } from 'html-to-image';
+import { windArrow } from '@/lib/utils';
 
 interface WeatherTableProps {
   track: ProcessedTrack | null;
@@ -26,18 +27,12 @@ export function WeatherTable({ track }: WeatherTableProps) {
     );
   }
 
-  const arrow = (deg: number) => {
-    const arrows = ['↑','↗','→','↘','↓','↙','←','↖'];
-    const idx = Math.round(deg / 45) % 8;
-    return arrows[idx];
-  };
-
   return (
     <div className="p-4 space-y-2">
       <div className="flex justify-end">
         <Button size="sm" onClick={exportPng}>Export PNG</Button>
       </div>
-      <div ref={tableRef} className="overflow-hidden">
+      <div ref={tableRef} className="max-w-[600px] mx-auto overflow-auto max-h-80">
         <Table>
           <TableHeader>
             <TableRow>
@@ -52,7 +47,7 @@ export function WeatherTable({ track }: WeatherTableProps) {
               <TableRow key={idx}>
                 <TableCell>{idx + 1}</TableCell>
                 <TableCell>{`${w.apparent_temperature_min.toFixed(0)}-${w.apparent_temperature_max.toFixed(0)}`}</TableCell>
-                <TableCell>{`${w.wind_speed_10m_max.toFixed(0)} km/h ${arrow(w.wind_direction_10m_dominant)}`}</TableCell>
+                <TableCell>{`${w.wind_speed_10m_max.toFixed(0)} km/h ${windArrow(w.wind_direction_10m_dominant)}`}</TableCell>
                 <TableCell>{w.rain_sum.toFixed(1)}</TableCell>
               </TableRow>
             ))}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -182,16 +182,16 @@ export function calculateDistance(lat1: number, lon1: number, lat2: number, lon2
 
 export async function fetchWeather(
   lat: number,
-  lon: number
+  lon: number,
+  date: string = new Date().toISOString().split('T')[0]
 ): Promise<WeatherData> {
-  const date = new Date().toISOString().split('T')[0];
 
   const cacheKey = `weather-${lat.toFixed(4)}-${lon.toFixed(4)}-${date}`;
   let daily = getWeatherFromCache(cacheKey);
 
   if (!daily) {
     const response = await fetch(
-      `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&daily=apparent_temperature_max,apparent_temperature_min,wind_speed_10m_max,wind_direction_10m_dominant,rain_sum&timezone=auto&forecast_days=1`
+      `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&start_date=${date}&end_date=${date}&daily=apparent_temperature_max,apparent_temperature_min,wind_speed_10m_max,wind_direction_10m_dominant,rain_sum&timezone=auto`
     );
     const data = await response.json();
     daily = {
@@ -305,15 +305,16 @@ export function saveSettings(settings: import('../types').UserSettings): void {
 }
 
 export function loadSettings(): import('../types').UserSettings {
+  const defaults = { forecastDate: new Date().toISOString().split('T')[0] };
   try {
     const saved = localStorage.getItem('user-settings');
     if (saved) {
-      return JSON.parse(saved);
+      return { ...defaults, ...JSON.parse(saved) };
     }
   } catch (error) {
     console.error('Error loading settings:', error);
   }
-  return {} as import('../types').UserSettings;
+  return defaults as import('../types').UserSettings;
 }
 
 export function calculateBounds(points: GpxPoint[]) {
@@ -359,4 +360,10 @@ export function exportWeatherPdf(
   });
 
   doc.save(`${title}.pdf`);
+}
+
+export function windArrow(deg: number): string {
+  const arrows = ['↑', '↗', '→', '↘', '↓', '↙', '←', '↖'];
+  const idx = Math.round(deg / 45) % 8;
+  return arrows[idx];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -50,5 +50,6 @@ export interface WeatherCache {
 }
 
 export interface UserSettings {
-  // Intentionally left blank for future preferences
+  /** ISO date (YYYY-MM-DD) for weather forecast */
+  forecastDate: string;
 }


### PR DESCRIPTION
## Summary
- implement global forecast date setting with new `DatePicker`
- display wind direction arrows on map labels
- limit weather table width, enable scrolling, add sticky header
- allow choosing forecast date from -1 to +7 days

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885fe2f88888331b26002856ce2eb67